### PR TITLE
Update @architect/architect to 5.7.0 and @architect/functions to 3.0.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,14 +5,14 @@
   "requires": true,
   "dependencies": {
     "@architect/architect": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/@architect/architect/-/architect-5.0.6.tgz",
-      "integrity": "sha512-Wcyv3S1UkkzKAIsKKYQSXgrMc0yL8rDngv9Y/WIA/rMP45QrsEFisHnQH1a4wV1UMPr+bFR23FNVBbAVWBsVJA==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@architect/architect/-/architect-5.7.0.tgz",
+      "integrity": "sha512-vq8OchXY1Fo6Jdak4EpEVeok7b6MvU6+mIdbBHLi1cGbr2fLQj8TjWmf4vSzQb1jMIXtiJC0HoI0OspBHEudgw==",
       "requires": {
-        "@architect/data": "^2.0.12",
-        "@architect/parser": "^1.1.6",
+        "@architect/data": "^2.0.14",
+        "@architect/parser": "^1.1.7",
         "@smallwins/validate": "^4.3.0",
-        "aws-sdk": "^2.392.0",
+        "aws-sdk": "^2.421.0",
         "body-parser": "^1.18.3",
         "chalk": "^2.4.2",
         "clear": "^0.1.0",
@@ -20,10 +20,10 @@
         "dynalite": "^2.2.0",
         "finalhandler": "^1.1.1",
         "glob": "^7.1.3",
-        "inquirer": "^6.2.1",
+        "inquirer": "^6.2.2",
         "is-domain-name": "^1.0.1",
         "log-update": "^2.3.0",
-        "mime-types": "^2.1.20",
+        "mime-types": "^2.1.22",
         "mkdirp": "^0.5.1",
         "path-exists": "^3.0.0",
         "router": "^1.3.3",
@@ -31,17 +31,17 @@
         "run-series": "^1.1.8",
         "run-waterfall": "^1.1.3",
         "send": "^0.16.2",
-        "shallow-equal": "^1.0.0",
+        "shallow-equal": "^1.1.0",
         "strftime": "^0.10.0",
-        "ws": "^6.1.2",
+        "ws": "^6.2.0",
         "zip-dir": "^1.0.2",
         "zipit": "^1.0.2"
       }
     },
     "@architect/data": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/@architect/data/-/data-2.0.14.tgz",
-      "integrity": "sha512-BtK2MySTTZwmSl/6d+1kgov2RSyh4BwpTTxodfuGAv5h3jclKSTfBSUkYn1sxfPuqNo1yFrBhYsEi08GK/Ic1Q==",
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@architect/data/-/data-2.0.17.tgz",
+      "integrity": "sha512-TrjGHioRjHSfqF76aq0wQJy1y5h7/cgs1svsbWXl68IF9eAAjsFH1fglvRkmvASyAoJEHmhMeSy17e1uOrHzzg==",
       "requires": {
         "@architect/parser": "^1.1.6",
         "chalk": "^2.4.2",
@@ -49,15 +49,15 @@
       }
     },
     "@architect/functions": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@architect/functions/-/functions-2.0.7.tgz",
-      "integrity": "sha512-rw1aJeOt9CZuUHP5f475pAfyNhWLuZ8xOkwQ/HM3My7BkaYE8mYjVfRH7vtPOwZUI6r9Je4oQ57QYwIE/DQBGw==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@architect/functions/-/functions-3.0.5.tgz",
+      "integrity": "sha512-ISV9lt0QaDhv7FoD+cY2Wpes1Lyq1Bl27tA7aj9CKLpYd7JXRp+dXk5rILnjTR7sH88g3AKBmH4zB7fPJ+o4nQ==",
       "requires": {
         "@architect/parser": "^1.1.6",
         "cookie": "^0.3.1",
         "cookie-signature": "^1.1.0",
         "csrf": "^3.0.6",
-        "mime-types": "^2.1.21",
+        "mime-types": "^2.1.22",
         "node-webtokens": "^1.0.0",
         "run-parallel": "^1.1.9",
         "run-waterfall": "^1.1.6",
@@ -65,9 +65,9 @@
       }
     },
     "@architect/parser": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@architect/parser/-/parser-1.1.6.tgz",
-      "integrity": "sha512-xBu7s17FV9UQGNjUrNY6EObwJMdgV00NIPBJIJ11OVVyeDhcU5HaXSkllx91+oJQ4GvhUkguIJr6hz6saLrVRQ=="
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@architect/parser/-/parser-1.1.7.tgz",
+      "integrity": "sha512-fKyd7apWktnS580bOa75bWtx+RVxuhLNYjcaDrRRpuASTT4F+Gg4dZly8eGGehPHAQ3j3/0pLwnChiC2+fHozg=="
     },
     "@smallwins/nodash": {
       "version": "1.0.0",
@@ -98,8 +98,7 @@
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "optional": true
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -131,11 +130,11 @@
       "integrity": "sha1-Qmu52oQJDBg42BLIFQryCoMx4pY="
     },
     "async": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
-      "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.2.tgz",
+      "integrity": "sha512-H1qVYh1MYhEEFLsP97cVKqCGo7KfCyTt6uEWqsTBr9SO84oK9Uwbyd/yCW+6rKJLHksBNUVWZDAjfS+Ccx0Bbg==",
       "requires": {
-        "lodash": "^4.17.10"
+        "lodash": "^4.17.11"
       }
     },
     "async-limiter": {
@@ -144,9 +143,9 @@
       "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
     },
     "aws-sdk": {
-      "version": "2.401.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.401.0.tgz",
-      "integrity": "sha512-mOI4gzKoP/g8Q0ToAaqTh7TijGG9PvGVVUkKmurXqBKy7GTPmy4JizfVkTrM+iBg7RAsx5H2lBxBFpdEFBa5fg==",
+      "version": "2.442.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.442.0.tgz",
+      "integrity": "sha512-1KWya47PNEKJiIRQ4l3B+31gSwfaxa+1ow/o8HMmUAQl7wM5SDotUz+v6y2e08R4sL3u7UN+DWMkhg1itpYZIQ==",
       "requires": {
         "buffer": "4.9.1",
         "events": "1.1.1",
@@ -300,8 +299,7 @@
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-      "optional": true
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "color-convert": {
       "version": "1.9.3",
@@ -324,8 +322,7 @@
     "console-control-strings": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-      "optional": true
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
     },
     "content-type": {
       "version": "1.0.4",
@@ -359,23 +356,13 @@
       }
     },
     "csrf": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/csrf/-/csrf-3.0.6.tgz",
-      "integrity": "sha1-thEg3c7q/JHnbtUxO7XAsmZ7cQo=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/csrf/-/csrf-3.1.0.tgz",
+      "integrity": "sha512-uTqEnCvWRk042asU6JtapDTcJeeailFy4ydOQS28bj1hcLnYRiqi8SsD2jS412AY1I/4qdOwWZun774iqywf9w==",
       "requires": {
         "rndm": "1.2.0",
-        "tsscmp": "1.0.5",
-        "uid-safe": "2.1.4"
-      },
-      "dependencies": {
-        "uid-safe": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.4.tgz",
-          "integrity": "sha1-Otbzg2jG1MjHXsF2I/t5qh0HHYE=",
-          "requires": {
-            "random-bytes": "~1.0.0"
-          }
-        }
+        "tsscmp": "1.0.6",
+        "uid-safe": "2.1.5"
       }
     },
     "debug": {
@@ -402,18 +389,18 @@
       "optional": true
     },
     "deferred-leveldown": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-5.0.0.tgz",
-      "integrity": "sha512-QtTcNm2PX7elim5bGl+i3px2kVbpI49BV+Q62CFh0AaMlrdlbMXyozBg31p2zJqAAT35FUw4eccC+drr3D0+vQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-5.0.1.tgz",
+      "integrity": "sha512-BXohsvTedWOLkj2n/TY+yqVlrCWa2Zs8LSxh3uCAgFOru7/pjxKyZAexGa1j83BaKloER4PqUyQ9rGPJLt9bqA==",
       "requires": {
         "abstract-leveldown": "~6.0.0",
         "inherits": "^2.0.3"
       },
       "dependencies": {
         "abstract-leveldown": {
-          "version": "6.0.1",
-          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.0.1.tgz",
-          "integrity": "sha512-8ccQIKHwmh7rIRWvKGgSTM2LByLWpLZgAYRjDNOh1ZTXvlR0gtm2Ir7aD8rEUre8DMllchJJTAZhhN5aUBN7XA==",
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.0.2.tgz",
+          "integrity": "sha512-AaEmQKBazexOeFp2tu+TnGWFhTudFMFK7yOdzJ5VlQyvZDmP6ff8R75JDDVtLCCi+hK5L8DVWaDe51w3uONqCA==",
           "requires": {
             "level-concat-iterator": "~2.0.0",
             "xtend": "~4.0.0"
@@ -492,7 +479,6 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
-      "optional": true,
       "requires": {
         "once": "^1.4.0"
       }
@@ -526,9 +512,9 @@
       "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
     },
     "expand-template": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.1.1.tgz",
-      "integrity": "sha512-cebqLtV8KOZfw0UI8TEFWxtczxxC1jvyUvx6H4fyp1K1FN7A4Q+uggVUlOsI1K8AGU0rwOGqP8nCapdrw8CYQg==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
       "optional": true
     },
     "external-editor": {
@@ -708,9 +694,9 @@
       "optional": true
     },
     "inquirer": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.2.tgz",
-      "integrity": "sha512-Z2rREiXA6cHRR9KBOarR3WuLlFzlIfAEIiB45ll5SSadMg7WqOh1MKEjjndfuH5ewXdixWCxqnVfGOQzPeiztA==",
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.3.1.tgz",
+      "integrity": "sha512-MmL624rfkFt4TG9y/Jvmt8vdmOo836U7Y0Hxr2aFk3RelZEGX4Igk0KabWrcaaZaTv9uzglOqWh1Vly+FAWAXA==",
       "requires": {
         "ansi-escapes": "^3.2.0",
         "chalk": "^2.4.2",
@@ -723,7 +709,7 @@
         "run-async": "^2.2.0",
         "rxjs": "^6.4.0",
         "string-width": "^2.1.0",
-        "strip-ansi": "^5.0.0",
+        "strip-ansi": "^5.1.0",
         "through": "^2.3.6"
       },
       "dependencies": {
@@ -757,17 +743,17 @@
           }
         },
         "strip-ansi": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.0.0.tgz",
-          "integrity": "sha512-Uu7gQyZI7J7gn5qLn1Np3G9vcYGTVqB+lFTytnDJv83dd8T22aGH451P3jueT2/QemInJDfxHB5Tde5OzgG1Ow==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "requires": {
-            "ansi-regex": "^4.0.0"
+            "ansi-regex": "^4.1.0"
           },
           "dependencies": {
             "ansi-regex": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.0.0.tgz",
-              "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w=="
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
             }
           }
         }
@@ -787,7 +773,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-      "optional": true,
       "requires": {
         "number-is-nan": "^1.0.0"
       }
@@ -821,27 +806,27 @@
       "integrity": "sha1-2qBoIGKCVCwIgojpdcKXwa53tpA="
     },
     "level-codec": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.0.tgz",
-      "integrity": "sha512-OIpVvjCcZNP5SdhcNupnsI1zo5Y9Vpm+k/F1gfG5kXrtctlrwanisakweJtE0uA0OpLukRfOQae+Fg0M5Debhg=="
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.1.tgz",
+      "integrity": "sha512-ajFP0kJ+nyq4i6kptSM+mAvJKLOg1X5FiFPtLG9M5gCEZyBmgDi3FkDrvlMkEzrUn1cWxtvVmrvoS4ASyO/q+Q=="
     },
     "level-concat-iterator": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/level-concat-iterator/-/level-concat-iterator-2.0.0.tgz",
-      "integrity": "sha512-gMs7JtWp479SOBjJQteQ+WMctfiQXG1SX5EuIGWTTUP37mKqs6BcYcjfZVVzAdTq0lAcSYpL2xGwmCG/hbjOcg=="
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/level-concat-iterator/-/level-concat-iterator-2.0.1.tgz",
+      "integrity": "sha512-OTKKOqeav2QWcERMJR7IS9CUo1sHnke2C0gkSmcR7QuEtFNLLzHQAvnMw8ykvEcv0Qtkg0p7FOwP1v9e5Smdcw=="
     },
     "level-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.0.tgz",
-      "integrity": "sha512-AmY4HCp9h3OiU19uG+3YWkdELgy05OTP/r23aNHaQKWv8DO787yZgsEuGVkoph40uwN+YdUKnANlrxSsoOaaxg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.1.tgz",
+      "integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
       "requires": {
         "errno": "~0.1.1"
       }
     },
     "level-iterator-stream": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-4.0.0.tgz",
-      "integrity": "sha512-CHMqFgIGXmqbdfvZcNADxRBXrl2W2EN8stxZnxEDQfEN+oNULcbX1OSK7VqJutp51Z0yJtA4Ym3JJMOuEslTrA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-4.0.1.tgz",
+      "integrity": "sha512-pSZWqXK6/yHQkZKCHrR59nKpU5iqorKM22C/BOHTb/cwNQ2EOZG+bovmFFGcOgaBoF3KxqJEI27YwewhJQTzsw==",
       "requires": {
         "inherits": "^2.0.1",
         "readable-stream": "^3.0.2",
@@ -849,9 +834,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.1.1.tgz",
-          "integrity": "sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==",
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
+          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
           "requires": {
             "inherits": "^2.0.3",
             "string_decoder": "^1.1.1",
@@ -869,22 +854,22 @@
       }
     },
     "leveldown": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-4.0.1.tgz",
-      "integrity": "sha512-ZlBKVSsglPIPJnz4ggB8o2R0bxDxbsMzuQohbfgoFMVApyTE118DK5LNRG0cRju6rt3OkGxe0V6UYACGlq/byg==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-4.0.2.tgz",
+      "integrity": "sha512-SUgSRTWFh3eeiTdIt2a4Fi9TZO5oWzE9uC/Iw8+fVr1sk8x1S2l151UWwSmrMFZB3GxJhZIf4bQ0n+051Cctpw==",
       "optional": true,
       "requires": {
         "abstract-leveldown": "~5.0.0",
         "bindings": "~1.3.0",
         "fast-future": "~1.0.2",
-        "nan": "~2.10.0",
-        "prebuild-install": "^4.0.0"
+        "nan": "~2.12.1",
+        "prebuild-install": "~5.2.4"
       }
     },
     "levelup": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/levelup/-/levelup-4.0.0.tgz",
-      "integrity": "sha512-RcWkjtMj1DGs8ftNs4U7MEZeHFnC9QcHn/fmBlOypHXCx02zwukZROzyUwRiu9dgw9y1tCDLFMmXQHEhCChi4w==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/levelup/-/levelup-4.0.1.tgz",
+      "integrity": "sha512-l7KXOkINXHgNqmz0v9bxvRnMCUG4gmShFrzFSZXXhcqFnfvKAW8NerVsTICpZtVhGOMAmhY6JsVoVh/tUPBmdg==",
       "requires": {
         "deferred-leveldown": "~5.0.0",
         "level-errors": "~2.0.0",
@@ -946,16 +931,16 @@
       "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
     },
     "mime-db": {
-      "version": "1.37.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
-      "integrity": "sha512-R3C4db6bgQhlIhPU48fUtdVmKnflq+hRdad7IyKhtFj06VPNVdk2RhiYL3UjQIlso8L+YxAtFkobT0VK+S/ybg=="
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
     },
     "mime-types": {
-      "version": "2.1.21",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
-      "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+      "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
       "requires": {
-        "mime-db": "~1.37.0"
+        "mime-db": "1.40.0"
       }
     },
     "mimic-fn": {
@@ -1008,9 +993,15 @@
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
     },
     "nan": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
-      "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA==",
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
+      "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==",
+      "optional": true
+    },
+    "napi-build-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.1.tgz",
+      "integrity": "sha512-boQj1WFgQH3v4clhu3mTNfP+vOBxorDlE8EKiMjUlLG3C4qAESnn9AxIOkFgTR2c9LtzNjPrjS60cT27ZKBhaA==",
       "optional": true
     },
     "node-abi": {
@@ -1048,8 +1039,7 @@
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-      "optional": true
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
     "object-assign": {
       "version": "4.1.1",
@@ -1093,14 +1083,14 @@
       "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "pako": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.8.tgz",
-      "integrity": "sha512-6i0HVbUfcKaTv+EG8ZTr75az7GFXcLYk9UyLEg7Notv/Ma+z/UG3TCoz6GiNeOrn1E/e63I0X/Hpw18jHOTUnA=="
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
+      "integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw=="
     },
     "parseurl": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
-      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ=="
     },
     "path-exists": {
       "version": "3.0.0",
@@ -1118,22 +1108,23 @@
       "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
     "prebuild-install": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-4.0.0.tgz",
-      "integrity": "sha512-7tayxeYboJX0RbVzdnKyGl2vhQRWr6qfClEXDhOkXjuaOKCw2q8aiuFhONRYVsG/czia7KhpykIlI2S2VaPunA==",
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.2.5.tgz",
+      "integrity": "sha512-6uZgMVg7yDfqlP5CPurVhtq3hUKBFNufiar4J5hZrlHTo59DDBEtyxw01xCdFss9j0Zb9+qzFVf/s4niayba3w==",
       "optional": true,
       "requires": {
         "detect-libc": "^1.0.3",
-        "expand-template": "^1.0.2",
+        "expand-template": "^2.0.3",
         "github-from-package": "0.0.0",
         "minimist": "^1.2.0",
         "mkdirp": "^0.5.1",
-        "node-abi": "^2.2.0",
+        "napi-build-utils": "^1.0.1",
+        "node-abi": "^2.7.0",
         "noop-logger": "^0.1.1",
         "npmlog": "^4.0.1",
         "os-homedir": "^1.0.1",
         "pump": "^2.0.1",
-        "rc": "^1.1.6",
+        "rc": "^1.2.7",
         "simple-get": "^2.7.0",
         "tar-fs": "^1.13.0",
         "tunnel-agent": "^0.6.0",
@@ -1282,9 +1273,9 @@
       "integrity": "sha512-dApPbpIK0hbFi2zqfJxrsnfmJW2HCQHFrSsmqF3Fp9TKm5WVf++zE6BSw0hPcA7rPapO37h12Swk2E6Va3tF7Q=="
     },
     "rxjs": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.4.0.tgz",
-      "integrity": "sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.1.tgz",
+      "integrity": "sha512-y0j31WJc83wPu31vS1VlAFW5JGrnGC+j+TtGAa1fRQphy48+fDYiDmX8tjGloToEsMkxnouOg/1IzXGKkJnZMg==",
       "requires": {
         "tslib": "^1.9.0"
       }
@@ -1305,9 +1296,9 @@
       "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
     },
     "semver": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
-      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
       "optional": true
     },
     "send": {
@@ -1389,7 +1380,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-      "optional": true,
       "requires": {
         "code-point-at": "^1.0.0",
         "is-fullwidth-code-point": "^1.0.0",
@@ -1408,7 +1398,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-      "optional": true,
       "requires": {
         "ansi-regex": "^2.0.0"
       }
@@ -1535,9 +1524,9 @@
       "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     },
     "tsscmp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.5.tgz",
-      "integrity": "sha1-fcSjOvcVgatDN9qR2FylQn69mpc="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA=="
     },
     "tunnel-agent": {
       "version": "0.6.0",
@@ -1653,9 +1642,9 @@
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "ws": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.3.tgz",
-      "integrity": "sha512-tbSxiT+qJI223AP4iLfQbkbxkwdFcneYinM2+x46Gx2wgvbaOMO36czfdfVUBRTHvzAMRhDd98sA5d/BuWbQdg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.1.tgz",
+      "integrity": "sha512-GIyAXC2cB7LjvpgMt9EKS2ldqr0MTrORaleiOno6TweZ6r3TKtoFQWay/2PceJ3RuBasOHzXNn5Lrw1X0bEjqA==",
       "requires": {
         "async-limiter": "~1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "Brian LeRoux <b@brian.io>",
   "license": "Apache-2.0",
   "dependencies": {
-    "@architect/architect": "^5.0.6",
-    "@architect/functions": "^2.0.7"
+    "@architect/architect": "^5.7.0",
+    "@architect/functions": "^3.0.5"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -9,3 +9,7 @@ npm i
 npx hydrate
 npx sandbox 
 ```
+
+# deploying to Lambda
+
+if you want to deploy to Lambda you need to add an `@aws` entry (https://arc.codes/reference/aws) and staging and production entries for `@static` (https://arc.codes/reference/static) in `.arc`

--- a/src/http/get-index/index.js
+++ b/src/http/get-index/index.js
@@ -1,3 +1,5 @@
+let arc = require('@architect/functions')
+let static = arc.http.helpers.static
 let getURL = require('./get-web-socket-url')
 
 /**
@@ -5,7 +7,7 @@ let getURL = require('./get-web-socket-url')
  */
 exports.handler = async function http(req) {
   return {
-    type: 'text/html; charset=utf8',
+    headers: {'content-type': 'text/html; charset=utf8'},
     body: `<!doctype html>
 <html>
 <body>
@@ -15,7 +17,7 @@ exports.handler = async function http(req) {
 <script>
 window.WS_URL = '${getURL()}'
 </script>
-<script type=module src=/index.mjs></script>
+<script type=module src=${static('/index.mjs')}></script>
 </body>
 </html>`
   }

--- a/src/http/get-index/package-lock.json
+++ b/src/http/get-index/package-lock.json
@@ -14,20 +14,18 @@
       }
     },
     "@architect/functions": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@architect/functions/-/functions-1.12.1.tgz",
-      "integrity": "sha512-wJ3fZl8IULh5cq+kkTi6FmiCziMQuIyDV6owNX+tMZF52jlA0+ttstljw3Ue2DSBNZq9uTfFTSrckuvP4EIEOA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@architect/functions/-/functions-3.0.5.tgz",
+      "integrity": "sha512-ISV9lt0QaDhv7FoD+cY2Wpes1Lyq1Bl27tA7aj9CKLpYd7JXRp+dXk5rILnjTR7sH88g3AKBmH4zB7fPJ+o4nQ==",
       "requires": {
-        "@architect/parser": "^1.1.0",
-        "@smallwins/err": "^1.0.0",
+        "@architect/parser": "^1.1.6",
         "cookie": "^0.3.1",
         "cookie-signature": "^1.1.0",
         "csrf": "^3.0.6",
-        "is-plain-object": "^2.0.4",
+        "mime-types": "^2.1.22",
         "node-webtokens": "^1.0.0",
         "run-parallel": "^1.1.9",
         "run-waterfall": "^1.1.6",
-        "serialize-error": "^2.1.0",
         "uid-safe": "^2.1.5"
       }
     },
@@ -35,15 +33,6 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@architect/parser/-/parser-1.1.6.tgz",
       "integrity": "sha512-xBu7s17FV9UQGNjUrNY6EObwJMdgV00NIPBJIJ11OVVyeDhcU5HaXSkllx91+oJQ4GvhUkguIJr6hz6saLrVRQ=="
-    },
-    "@smallwins/err": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@smallwins/err/-/err-1.0.0.tgz",
-      "integrity": "sha1-tk2WSldWcGukV/Dhwtem7h2GZwA=",
-      "requires": {
-        "clean-stack": "^1.3.0",
-        "serialize-error": "^2.1.0"
-      }
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -62,11 +51,6 @@
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
       }
-    },
-    "clean-stack": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-1.3.0.tgz",
-      "integrity": "sha1-noIVAa6XmYbEax1m0tQy2y/UrjE="
     },
     "color-convert": {
       "version": "1.9.3",
@@ -92,23 +76,13 @@
       "integrity": "sha512-Alvs19Vgq07eunykd3Xy2jF0/qSNv2u7KDbAek9H5liV1UMijbqFs5cycZvv5dVsvseT/U4H8/7/w8Koh35C4A=="
     },
     "csrf": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/csrf/-/csrf-3.0.6.tgz",
-      "integrity": "sha1-thEg3c7q/JHnbtUxO7XAsmZ7cQo=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/csrf/-/csrf-3.1.0.tgz",
+      "integrity": "sha512-uTqEnCvWRk042asU6JtapDTcJeeailFy4ydOQS28bj1hcLnYRiqi8SsD2jS412AY1I/4qdOwWZun774iqywf9w==",
       "requires": {
         "rndm": "1.2.0",
-        "tsscmp": "1.0.5",
-        "uid-safe": "2.1.4"
-      },
-      "dependencies": {
-        "uid-safe": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.4.tgz",
-          "integrity": "sha1-Otbzg2jG1MjHXsF2I/t5qh0HHYE=",
-          "requires": {
-            "random-bytes": "~1.0.0"
-          }
-        }
+        "tsscmp": "1.0.6",
+        "uid-safe": "2.1.5"
       }
     },
     "escape-string-regexp": {
@@ -121,18 +95,18 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
-    "is-plain-object": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-      "requires": {
-        "isobject": "^3.0.1"
-      }
+    "mime-db": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
     },
-    "isobject": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+    "mime-types": {
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+      "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+      "requires": {
+        "mime-db": "1.40.0"
+      }
     },
     "node-webtokens": {
       "version": "1.0.0",
@@ -164,11 +138,6 @@
       "resolved": "https://registry.npmjs.org/run-waterfall/-/run-waterfall-1.1.6.tgz",
       "integrity": "sha512-dApPbpIK0hbFi2zqfJxrsnfmJW2HCQHFrSsmqF3Fp9TKm5WVf++zE6BSw0hPcA7rPapO37h12Swk2E6Va3tF7Q=="
     },
-    "serialize-error": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
-      "integrity": "sha1-ULZ51WNc34Rme9yOWa9OW4HV9go="
-    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -178,9 +147,9 @@
       }
     },
     "tsscmp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.5.tgz",
-      "integrity": "sha1-fcSjOvcVgatDN9qR2FylQn69mpc="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA=="
     },
     "uid-safe": {
       "version": "2.1.5",

--- a/src/http/get-index/package.json
+++ b/src/http/get-index/package.json
@@ -2,6 +2,6 @@
   "name": "test-ws-get-index",
   "dependencies": {
     "@architect/data": "^2.0.9",
-    "@architect/functions": "^1.12.1"
+    "@architect/functions": "^3.0.5"
   }
 }

--- a/src/ws/ws-connect/package-lock.json
+++ b/src/ws/ws-connect/package-lock.json
@@ -14,20 +14,18 @@
       }
     },
     "@architect/functions": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@architect/functions/-/functions-1.12.1.tgz",
-      "integrity": "sha512-wJ3fZl8IULh5cq+kkTi6FmiCziMQuIyDV6owNX+tMZF52jlA0+ttstljw3Ue2DSBNZq9uTfFTSrckuvP4EIEOA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@architect/functions/-/functions-3.0.5.tgz",
+      "integrity": "sha512-ISV9lt0QaDhv7FoD+cY2Wpes1Lyq1Bl27tA7aj9CKLpYd7JXRp+dXk5rILnjTR7sH88g3AKBmH4zB7fPJ+o4nQ==",
       "requires": {
-        "@architect/parser": "^1.1.0",
-        "@smallwins/err": "^1.0.0",
+        "@architect/parser": "^1.1.6",
         "cookie": "^0.3.1",
         "cookie-signature": "^1.1.0",
         "csrf": "^3.0.6",
-        "is-plain-object": "^2.0.4",
+        "mime-types": "^2.1.22",
         "node-webtokens": "^1.0.0",
         "run-parallel": "^1.1.9",
         "run-waterfall": "^1.1.6",
-        "serialize-error": "^2.1.0",
         "uid-safe": "^2.1.5"
       }
     },
@@ -35,15 +33,6 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@architect/parser/-/parser-1.1.6.tgz",
       "integrity": "sha512-xBu7s17FV9UQGNjUrNY6EObwJMdgV00NIPBJIJ11OVVyeDhcU5HaXSkllx91+oJQ4GvhUkguIJr6hz6saLrVRQ=="
-    },
-    "@smallwins/err": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@smallwins/err/-/err-1.0.0.tgz",
-      "integrity": "sha1-tk2WSldWcGukV/Dhwtem7h2GZwA=",
-      "requires": {
-        "clean-stack": "^1.3.0",
-        "serialize-error": "^2.1.0"
-      }
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -62,11 +51,6 @@
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
       }
-    },
-    "clean-stack": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-1.3.0.tgz",
-      "integrity": "sha1-noIVAa6XmYbEax1m0tQy2y/UrjE="
     },
     "color-convert": {
       "version": "1.9.3",
@@ -92,23 +76,13 @@
       "integrity": "sha512-Alvs19Vgq07eunykd3Xy2jF0/qSNv2u7KDbAek9H5liV1UMijbqFs5cycZvv5dVsvseT/U4H8/7/w8Koh35C4A=="
     },
     "csrf": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/csrf/-/csrf-3.0.6.tgz",
-      "integrity": "sha1-thEg3c7q/JHnbtUxO7XAsmZ7cQo=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/csrf/-/csrf-3.1.0.tgz",
+      "integrity": "sha512-uTqEnCvWRk042asU6JtapDTcJeeailFy4ydOQS28bj1hcLnYRiqi8SsD2jS412AY1I/4qdOwWZun774iqywf9w==",
       "requires": {
         "rndm": "1.2.0",
-        "tsscmp": "1.0.5",
-        "uid-safe": "2.1.4"
-      },
-      "dependencies": {
-        "uid-safe": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.4.tgz",
-          "integrity": "sha1-Otbzg2jG1MjHXsF2I/t5qh0HHYE=",
-          "requires": {
-            "random-bytes": "~1.0.0"
-          }
-        }
+        "tsscmp": "1.0.6",
+        "uid-safe": "2.1.5"
       }
     },
     "escape-string-regexp": {
@@ -121,18 +95,18 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
-    "is-plain-object": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-      "requires": {
-        "isobject": "^3.0.1"
-      }
+    "mime-db": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
     },
-    "isobject": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+    "mime-types": {
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+      "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+      "requires": {
+        "mime-db": "1.40.0"
+      }
     },
     "node-webtokens": {
       "version": "1.0.0",
@@ -164,11 +138,6 @@
       "resolved": "https://registry.npmjs.org/run-waterfall/-/run-waterfall-1.1.6.tgz",
       "integrity": "sha512-dApPbpIK0hbFi2zqfJxrsnfmJW2HCQHFrSsmqF3Fp9TKm5WVf++zE6BSw0hPcA7rPapO37h12Swk2E6Va3tF7Q=="
     },
-    "serialize-error": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
-      "integrity": "sha1-ULZ51WNc34Rme9yOWa9OW4HV9go="
-    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -178,9 +147,9 @@
       }
     },
     "tsscmp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.5.tgz",
-      "integrity": "sha1-fcSjOvcVgatDN9qR2FylQn69mpc="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA=="
     },
     "uid-safe": {
       "version": "2.1.5",

--- a/src/ws/ws-connect/package.json
+++ b/src/ws/ws-connect/package.json
@@ -2,6 +2,6 @@
   "name": "test-ws-ws-connect",
   "dependencies": {
     "@architect/data": "^2.0.9",
-    "@architect/functions": "^1.12.1"
+    "@architect/functions": "^3.0.5"
   }
 }

--- a/src/ws/ws-default/package-lock.json
+++ b/src/ws/ws-default/package-lock.json
@@ -14,20 +14,18 @@
       }
     },
     "@architect/functions": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@architect/functions/-/functions-1.12.1.tgz",
-      "integrity": "sha512-wJ3fZl8IULh5cq+kkTi6FmiCziMQuIyDV6owNX+tMZF52jlA0+ttstljw3Ue2DSBNZq9uTfFTSrckuvP4EIEOA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@architect/functions/-/functions-3.0.5.tgz",
+      "integrity": "sha512-ISV9lt0QaDhv7FoD+cY2Wpes1Lyq1Bl27tA7aj9CKLpYd7JXRp+dXk5rILnjTR7sH88g3AKBmH4zB7fPJ+o4nQ==",
       "requires": {
-        "@architect/parser": "^1.1.0",
-        "@smallwins/err": "^1.0.0",
+        "@architect/parser": "^1.1.6",
         "cookie": "^0.3.1",
         "cookie-signature": "^1.1.0",
         "csrf": "^3.0.6",
-        "is-plain-object": "^2.0.4",
+        "mime-types": "^2.1.22",
         "node-webtokens": "^1.0.0",
         "run-parallel": "^1.1.9",
         "run-waterfall": "^1.1.6",
-        "serialize-error": "^2.1.0",
         "uid-safe": "^2.1.5"
       }
     },
@@ -36,21 +34,43 @@
       "resolved": "https://registry.npmjs.org/@architect/parser/-/parser-1.1.6.tgz",
       "integrity": "sha512-xBu7s17FV9UQGNjUrNY6EObwJMdgV00NIPBJIJ11OVVyeDhcU5HaXSkllx91+oJQ4GvhUkguIJr6hz6saLrVRQ=="
     },
-    "@smallwins/err": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@smallwins/err/-/err-1.0.0.tgz",
-      "integrity": "sha1-tk2WSldWcGukV/Dhwtem7h2GZwA=",
-      "requires": {
-        "clean-stack": "^1.3.0",
-        "serialize-error": "^2.1.0"
-      }
-    },
     "ansi-styles": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "requires": {
         "color-convert": "^1.9.0"
+      }
+    },
+    "aws-sdk": {
+      "version": "2.443.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.443.0.tgz",
+      "integrity": "sha512-I4vjwridWEQDq6L6GE3AsV0MzvRI1drPbHtxbI/K4Q4lmwMkskue+qiSlac4EY3ZJBuBIXGgIclKnkr8AuW71g==",
+      "requires": {
+        "buffer": "4.9.1",
+        "events": "1.1.1",
+        "ieee754": "1.1.8",
+        "jmespath": "0.15.0",
+        "querystring": "0.2.0",
+        "sax": "1.2.1",
+        "url": "0.10.3",
+        "uuid": "3.3.2",
+        "xml2js": "0.4.19"
+      }
+    },
+    "base64-js": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.0.tgz",
+      "integrity": "sha512-ccav/yGvoa80BQDljCxsmmQ3Xvx60/UpBIij5QN21W3wBi/hhIC9OoO+KLpu9IJTS9j4DRVJ3aDDF9cMSoa2lw=="
+    },
+    "buffer": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+      "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+      "requires": {
+        "base64-js": "^1.0.2",
+        "ieee754": "^1.1.4",
+        "isarray": "^1.0.0"
       }
     },
     "chalk": {
@@ -62,11 +82,6 @@
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
       }
-    },
-    "clean-stack": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-1.3.0.tgz",
-      "integrity": "sha1-noIVAa6XmYbEax1m0tQy2y/UrjE="
     },
     "color-convert": {
       "version": "1.9.3",
@@ -92,23 +107,13 @@
       "integrity": "sha512-Alvs19Vgq07eunykd3Xy2jF0/qSNv2u7KDbAek9H5liV1UMijbqFs5cycZvv5dVsvseT/U4H8/7/w8Koh35C4A=="
     },
     "csrf": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/csrf/-/csrf-3.0.6.tgz",
-      "integrity": "sha1-thEg3c7q/JHnbtUxO7XAsmZ7cQo=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/csrf/-/csrf-3.1.0.tgz",
+      "integrity": "sha512-uTqEnCvWRk042asU6JtapDTcJeeailFy4ydOQS28bj1hcLnYRiqi8SsD2jS412AY1I/4qdOwWZun774iqywf9w==",
       "requires": {
         "rndm": "1.2.0",
-        "tsscmp": "1.0.5",
-        "uid-safe": "2.1.4"
-      },
-      "dependencies": {
-        "uid-safe": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.4.tgz",
-          "integrity": "sha1-Otbzg2jG1MjHXsF2I/t5qh0HHYE=",
-          "requires": {
-            "random-bytes": "~1.0.0"
-          }
-        }
+        "tsscmp": "1.0.6",
+        "uid-safe": "2.1.5"
       }
     },
     "escape-string-regexp": {
@@ -116,23 +121,43 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
+    "events": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+      "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+    },
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
-    "is-plain-object": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-      "requires": {
-        "isobject": "^3.0.1"
-      }
+    "ieee754": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+      "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
     },
-    "isobject": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+    },
+    "jmespath": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+      "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+    },
+    "mime-db": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
+    },
+    "mime-types": {
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+      "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+      "requires": {
+        "mime-db": "1.40.0"
+      }
     },
     "node-webtokens": {
       "version": "1.0.0",
@@ -143,6 +168,16 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
       "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
+    },
+    "punycode": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+      "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+    },
+    "querystring": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+      "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
     "random-bytes": {
       "version": "1.0.0",
@@ -164,10 +199,10 @@
       "resolved": "https://registry.npmjs.org/run-waterfall/-/run-waterfall-1.1.6.tgz",
       "integrity": "sha512-dApPbpIK0hbFi2zqfJxrsnfmJW2HCQHFrSsmqF3Fp9TKm5WVf++zE6BSw0hPcA7rPapO37h12Swk2E6Va3tF7Q=="
     },
-    "serialize-error": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
-      "integrity": "sha1-ULZ51WNc34Rme9yOWa9OW4HV9go="
+    "sax": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+      "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
     },
     "supports-color": {
       "version": "5.5.0",
@@ -178,9 +213,9 @@
       }
     },
     "tsscmp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.5.tgz",
-      "integrity": "sha1-fcSjOvcVgatDN9qR2FylQn69mpc="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA=="
     },
     "uid-safe": {
       "version": "2.1.5",
@@ -189,6 +224,34 @@
       "requires": {
         "random-bytes": "~1.0.0"
       }
+    },
+    "url": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+      "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+      "requires": {
+        "punycode": "1.3.2",
+        "querystring": "0.2.0"
+      }
+    },
+    "uuid": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+    },
+    "xml2js": {
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+      "requires": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~9.0.1"
+      }
+    },
+    "xmlbuilder": {
+      "version": "9.0.7",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+      "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
     }
   }
 }

--- a/src/ws/ws-default/package.json
+++ b/src/ws/ws-default/package.json
@@ -2,6 +2,7 @@
   "name": "test-ws-ws-default",
   "dependencies": {
     "@architect/data": "^2.0.9",
-    "@architect/functions": "^1.12.1"
+    "@architect/functions": "^3.0.5",
+    "aws-sdk": "^2.443.0"
   }
 }

--- a/src/ws/ws-disconnect/package-lock.json
+++ b/src/ws/ws-disconnect/package-lock.json
@@ -14,20 +14,18 @@
       }
     },
     "@architect/functions": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@architect/functions/-/functions-1.12.1.tgz",
-      "integrity": "sha512-wJ3fZl8IULh5cq+kkTi6FmiCziMQuIyDV6owNX+tMZF52jlA0+ttstljw3Ue2DSBNZq9uTfFTSrckuvP4EIEOA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@architect/functions/-/functions-3.0.5.tgz",
+      "integrity": "sha512-ISV9lt0QaDhv7FoD+cY2Wpes1Lyq1Bl27tA7aj9CKLpYd7JXRp+dXk5rILnjTR7sH88g3AKBmH4zB7fPJ+o4nQ==",
       "requires": {
-        "@architect/parser": "^1.1.0",
-        "@smallwins/err": "^1.0.0",
+        "@architect/parser": "^1.1.6",
         "cookie": "^0.3.1",
         "cookie-signature": "^1.1.0",
         "csrf": "^3.0.6",
-        "is-plain-object": "^2.0.4",
+        "mime-types": "^2.1.22",
         "node-webtokens": "^1.0.0",
         "run-parallel": "^1.1.9",
         "run-waterfall": "^1.1.6",
-        "serialize-error": "^2.1.0",
         "uid-safe": "^2.1.5"
       }
     },
@@ -35,15 +33,6 @@
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/@architect/parser/-/parser-1.1.6.tgz",
       "integrity": "sha512-xBu7s17FV9UQGNjUrNY6EObwJMdgV00NIPBJIJ11OVVyeDhcU5HaXSkllx91+oJQ4GvhUkguIJr6hz6saLrVRQ=="
-    },
-    "@smallwins/err": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@smallwins/err/-/err-1.0.0.tgz",
-      "integrity": "sha1-tk2WSldWcGukV/Dhwtem7h2GZwA=",
-      "requires": {
-        "clean-stack": "^1.3.0",
-        "serialize-error": "^2.1.0"
-      }
     },
     "ansi-styles": {
       "version": "3.2.1",
@@ -62,11 +51,6 @@
         "escape-string-regexp": "^1.0.5",
         "supports-color": "^5.3.0"
       }
-    },
-    "clean-stack": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/clean-stack/-/clean-stack-1.3.0.tgz",
-      "integrity": "sha1-noIVAa6XmYbEax1m0tQy2y/UrjE="
     },
     "color-convert": {
       "version": "1.9.3",
@@ -92,23 +76,13 @@
       "integrity": "sha512-Alvs19Vgq07eunykd3Xy2jF0/qSNv2u7KDbAek9H5liV1UMijbqFs5cycZvv5dVsvseT/U4H8/7/w8Koh35C4A=="
     },
     "csrf": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/csrf/-/csrf-3.0.6.tgz",
-      "integrity": "sha1-thEg3c7q/JHnbtUxO7XAsmZ7cQo=",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/csrf/-/csrf-3.1.0.tgz",
+      "integrity": "sha512-uTqEnCvWRk042asU6JtapDTcJeeailFy4ydOQS28bj1hcLnYRiqi8SsD2jS412AY1I/4qdOwWZun774iqywf9w==",
       "requires": {
         "rndm": "1.2.0",
-        "tsscmp": "1.0.5",
-        "uid-safe": "2.1.4"
-      },
-      "dependencies": {
-        "uid-safe": {
-          "version": "2.1.4",
-          "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.4.tgz",
-          "integrity": "sha1-Otbzg2jG1MjHXsF2I/t5qh0HHYE=",
-          "requires": {
-            "random-bytes": "~1.0.0"
-          }
-        }
+        "tsscmp": "1.0.6",
+        "uid-safe": "2.1.5"
       }
     },
     "escape-string-regexp": {
@@ -121,18 +95,18 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
       "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
-    "is-plain-object": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-      "requires": {
-        "isobject": "^3.0.1"
-      }
+    "mime-db": {
+      "version": "1.40.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.40.0.tgz",
+      "integrity": "sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA=="
     },
-    "isobject": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
+    "mime-types": {
+      "version": "2.1.24",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.24.tgz",
+      "integrity": "sha512-WaFHS3MCl5fapm3oLxU4eYDw77IQM2ACcxQ9RIxfaC3ooc6PFuBMGZZsYpvoXS5D5QTWPieo1jjLdAm3TBP3cQ==",
+      "requires": {
+        "mime-db": "1.40.0"
+      }
     },
     "node-webtokens": {
       "version": "1.0.0",
@@ -164,11 +138,6 @@
       "resolved": "https://registry.npmjs.org/run-waterfall/-/run-waterfall-1.1.6.tgz",
       "integrity": "sha512-dApPbpIK0hbFi2zqfJxrsnfmJW2HCQHFrSsmqF3Fp9TKm5WVf++zE6BSw0hPcA7rPapO37h12Swk2E6Va3tF7Q=="
     },
-    "serialize-error": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-2.1.0.tgz",
-      "integrity": "sha1-ULZ51WNc34Rme9yOWa9OW4HV9go="
-    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -178,9 +147,9 @@
       }
     },
     "tsscmp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.5.tgz",
-      "integrity": "sha1-fcSjOvcVgatDN9qR2FylQn69mpc="
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/tsscmp/-/tsscmp-1.0.6.tgz",
+      "integrity": "sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA=="
     },
     "uid-safe": {
       "version": "2.1.5",

--- a/src/ws/ws-disconnect/package.json
+++ b/src/ws/ws-disconnect/package.json
@@ -2,6 +2,6 @@
   "name": "test-ws-ws-disconnect",
   "dependencies": {
     "@architect/data": "^2.0.9",
-    "@architect/functions": "^1.12.1"
+    "@architect/functions": "^3.0.5"
   }
 }


### PR DESCRIPTION
This requires also changing index.js to use the static path helper instead of directly referencing index.mjs and adding a dependency in ws-default for a higher version of aws-sdk.